### PR TITLE
Rotate vertical uploads

### DIFF
--- a/BookVisionWeb.Interface/BookVisionWeb.Interface.csproj
+++ b/BookVisionWeb.Interface/BookVisionWeb.Interface.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BookVisionWeb.UseCase\BookVisionWeb.UseCase.csproj" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/BookVisionWeb.Interface/BookVisionWeb.Interface.csproj
+++ b/BookVisionWeb.Interface/BookVisionWeb.Interface.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <ProjectReference Include="..\BookVisionWeb.UseCase\BookVisionWeb.UseCase.csproj" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/BookVisionWeb.Interface/Endpoints.cs
+++ b/BookVisionWeb.Interface/Endpoints.cs
@@ -2,7 +2,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using System.IO;
 using System;
-using System.Drawing;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
 using BookVisionWeb.Domain;
 using BookVisionWeb.UseCase;
 using Microsoft.Extensions.Hosting;
@@ -118,9 +119,9 @@ public static class Endpoints
             }
 
             // Rotate image 90 degrees counter‑clockwise for vertical text
-            using (var img = Image.FromFile(tempPath))
+            using (var img = Image.Load(tempPath))
             {
-                img.RotateFlip(RotateFlipType.Rotate270FlipNone);
+                img.Mutate(x => x.Rotate(RotateMode.Rotate270));
                 img.Save(tempPath);
             }
 

--- a/BookVisionWeb.Interface/Endpoints.cs
+++ b/BookVisionWeb.Interface/Endpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using System.IO;
 using System;
+using System.Drawing;
 using BookVisionWeb.Domain;
 using BookVisionWeb.UseCase;
 using Microsoft.Extensions.Hosting;
@@ -114,6 +115,13 @@ public static class Endpoints
             await using (var stream = File.Create(tempPath))
             {
                 await file.CopyToAsync(stream);
+            }
+
+            // Rotate image 90 degrees counter‑clockwise for vertical text
+            using (var img = Image.FromFile(tempPath))
+            {
+                img.RotateFlip(RotateFlipType.Rotate270FlipNone);
+                img.Save(tempPath);
             }
 
             var page = new Page(pageId, tempPath);

--- a/templates/main.html
+++ b/templates/main.html
@@ -21,6 +21,7 @@
                         <input type="submit" value="アップロード"
                             style="font-family:'MS Gothic';background:#FF0000;color:#FFFFFF;">
                     </form>
+                    <p style="color:#FF0000;font-family:'MS Gothic';">※縦書き画像専用です。横書きの画像には対応していません。</p>
                     <br>
                     <button id="coffeeBtn" type="button"
                         style="background:#00FF00;color:#000;font-family:'MS Gothic';">☕ コーヒーを淹れる</button>


### PR DESCRIPTION
## Summary
- rotate uploaded images 90 degrees counter-clockwise for vertical text
- add web notice that horizontal images are unsupported

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b9ad1a84832eab68fdf71abaf94f