### PR TITLE
Enhance HTTP 418 page

### DIFF
--- a/BookVisionWeb.Interface/Endpoints.cs
+++ b/BookVisionWeb.Interface/Endpoints.cs
@@ -142,8 +142,12 @@ public static class Endpoints
         });
 
         // --- Easter‑egg: HTTP 418 “I'm a teapot” ---
-        app.MapGet("/coffee", () =>
-            Results.Text("I'm a teapot ☕🫖", "text/plain; charset=utf-8", statusCode: 418));
+        app.MapGet("/coffee", (IHostEnvironment env) =>
+        {
+            var htmlPath = ResolveTemplatePath(env, "teapot_2000.html");
+            var html = File.ReadAllText(htmlPath);
+            return Results.Text(html, "text/html; charset=utf-8", statusCode: 418);
+        });
 
         return app;
     }

--- a/templates/teapot_2000.html
+++ b/templates/teapot_2000.html
@@ -1,0 +1,68 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>418 I'm a teapot</title>
+    <style>
+        body {
+            background-image: url('bg_tile.gif');
+            font-family: 'MS Gothic', Osaka, sans-serif;
+            color: #0000FF;
+            text-align: center;
+        }
+        h1 {
+            font-size: 48px;
+            color: #FF0000;
+            background-color: #FFFF00;
+        }
+        pre {
+            font-family: monospace;
+            background: #FFFFFF;
+            color: #FF00FF;
+            display: inline-block;
+            padding: 10px;
+            border: 2px solid #00FF00;
+        }
+        a {
+            font-family: 'MS Gothic';
+            background: #FFFF00;
+            color: #0000FF;
+            text-decoration: none;
+            border: 1px solid #FF00FF;
+            padding: 4px 12px;
+            margin-top: 12px;
+            display: inline-block;
+        }
+    </style>
+</head>
+<body>
+    <h1><blink>418 I'm a teapot!</blink></h1>
+    <div style="font-size:64px">☕🫖</div>
+    <pre>
+       (  )   (   )  )
+        ) (   )  (  (
+        ( )  (    ) )
+        _____________
+       <_____________> ___
+       |             |/ _ \
+       |               | | |
+       |               |_| |
+    ___|             |\___/
+   /    \___________/    \
+   \_____________________/
+    </pre>
+    <p>Sorry, I can't brew coffee. Try some tea instead!</p>
+    <a href="/">Return Home</a>
+    <bgsound src="bgm_sample.mid" loop="infinite">
+    <embed src="bgm_sample.mid" autostart="true" hidden="true">
+    <script>
+    function blink(){
+        var el=document.getElementsByTagName('blink');
+        for(var i=0;i<el.length;i++){
+            el[i].style.visibility = el[i].style.visibility=='hidden' ? 'visible' : 'hidden';
+        }
+    }
+    setInterval(blink,500);
+    </script>
+</body>
+</html>

--- a/templates/teapot_2000.html
+++ b/templates/teapot_2000.html
@@ -52,7 +52,7 @@
    \_____________________/
     </pre>
     <p>Sorry, I can't brew coffee. Try some tea instead!</p>
-    <a href="/">Return Home</a>
+    <a href="/upload">Return Home</a>
     <bgsound src="bgm_sample.mid" loop="infinite">
     <embed src="bgm_sample.mid" autostart="true" hidden="true">
     <script>


### PR DESCRIPTION
## Summary
- add a playful `teapot_2000.html` template
- serve the HTML template on `/coffee` for HTTP 418

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1baf52c832e9cf78c3bbfef39b5